### PR TITLE
Add stock check to AddProduct method

### DIFF
--- a/Grocery.App/ViewModels/GroceryListItemsViewModel.cs
+++ b/Grocery.App/ViewModels/GroceryListItemsViewModel.cs
@@ -71,7 +71,7 @@ namespace Grocery.App.ViewModels
         [RelayCommand]
         public void AddProduct(Product product)
         {
-            if (product == null) return;
+            if (product == null || product.Stock == 0) return;
             GroceryListItem item = new(0, GroceryList.Id, product.Id, 1);
             _groceryListItemsService.Add(item);
             product.Stock--;


### PR DESCRIPTION
Updated the `AddProduct` method in `GroceryListItemsViewModel` to include a condition that prevents adding a product if its stock is `0`. This ensures that products with no available stock cannot be added to the grocery list.